### PR TITLE
Make easy-gd complient with Node 4.x.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 node_js:
   - "0.12"
   - "0.10"
-  - "0.9"
   - "4.3"
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ node_js:
   - "0.12"
   - "0.10"
   - "4.3"
+  - "5"
+  - "6"
 
 before_install:
   - "sudo apt-get install -y libgd2-xpm-dev"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,25 @@
 language: node_js
+
 node_js:
   - "0.10"
   - "0.9"
-  - "0.8"
+  - "4.3"
+
 before_install:
   - "sudo apt-get install libgd2-xpm-dev"
+
+sudo: required
+
+dist: trusty
+
+addons:
+  apt:
+    sources:
+    # add PPAs with more up-to-date toolchains
+    - ubuntu-toolchain-r-test
+    - llvm-toolchain-precise-3.6
+    packages:
+    # install toolchains
+    - gcc-5
+    - g++-5
+    - clang-3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
 language: node_js
 
 node_js:
+  - "0.12"
   - "0.10"
   - "0.9"
   - "4.3"
 
 before_install:
-  - "sudo apt-get install libgd2-xpm-dev"
+  - "sudo apt-get install -y libgd2-xpm-dev"
 
 sudo: required
 

--- a/lib/image.js
+++ b/lib/image.js
@@ -69,7 +69,7 @@ exports.autoOrient = function autoOrient() {
     if (exif.Orientation && exif.Orientation !== 1) {
         if (!(exif.Orientation in orientations)) throw errors.UnsupportedOrientationError()
         var angle = orientations[exif.Orientation]
-        var rotated = gd.createTrueColor(angle % 180 ? this.height : this.width, angle % 180 ? this.width : this.height)
+        var rotated = gd.createTrueColorSync(angle % 180 ? this.height : this.width, angle % 180 ? this.width : this.height)
         this.copyRotated(rotated, rotated.width / 2, rotated.height / 2, 0, 0, this.width, this.height, angle)
         rotated.format = this.format
         rotated.exif = _.clone(this.exif)
@@ -122,7 +122,7 @@ exports.resize = vargs(function resize(options, callback) {
         }
     }
 
-    target = gd.createTrueColor(tw, th)
+    target = gd.createTrueColorSync(tw, th)
     target.format = this.format
     target.exif = _.clone(this.exif)
 
@@ -187,7 +187,7 @@ exports.watermark = vargs(function watermark(source, pos, callback) {
         var x = Math.round((image.width - wm.width) * pos.x)
         var y = Math.round((image.height - wm.height) * pos.y)
 
-        var watermarked = gd.createTrueColor(image.width, image.height)
+        var watermarked = gd.createTrueColorSync(image.width, image.height)
         watermarked.format = image.format
         watermarked.exif = _.clone(image.exif)
 

--- a/lib/opener.js
+++ b/lib/opener.js
@@ -52,7 +52,12 @@ function openImage(imageData, options) {
     if (!imageData.length) throw errors.EmptySourceError()
 
     var format = formats.getImageFormat(imageData)
-    var image = format.open(imageData)
+    var image
+    try {
+        image = format.open(imageData)
+    } catch(e) {
+        throw errors.IncompleteImageError()
+    }
     if (!image) throw errors.IncompleteImageError()
     image.format = format.label
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "url": "https://github.com/furagu/easy-gd/issues"
   },
   "dependencies": {
-    "node-gd": "~1.2.0",
+    "node-gd": "~1.3.1",
     "buffertools": "~2.1.2",
     "underscore": "~1.7.0",
     "exif-parser": "~0.1.7",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A simplified Node.js wrapper around GD image manipulation library with extra features making your life easier.",
   "main": "index.js",
   "scripts": {
-    "test": "node_modules/.bin/mocha --reporter spec --colors"
+    "test": "node_modules/.bin/mocha --reporter spec --colors 2>/dev/null"
+
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simplified Node.js wrapper around GD image manipulation library with extra features making your life easier.",
   "main": "index.js",
   "scripts": {
-    "test": "node_modules/.bin/mocha --reporter spec --colors 2>/dev/null"
+    "test": "node_modules/.bin/mocha --reporter spec --colors"
   },
   "repository": {
     "type": "git",
@@ -30,7 +30,7 @@
     "url": "https://github.com/furagu/easy-gd/issues"
   },
   "dependencies": {
-    "node-gd": "~1.0.1",
+    "node-gd": "~1.1.0",
     "buffertools": "~2.1.2",
     "underscore": "~1.7.0",
     "exif-parser": "~0.1.7",

--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
     "url": "https://github.com/furagu/easy-gd/issues"
   },
   "dependencies": {
-    "node-gd": "~1.3.1",
-    "buffertools": "~2.1.2",
-    "underscore": "~1.7.0",
+    "node-gd": "~1.5.0",
+    "buffertools": "~2.1.6",
+    "underscore": "~1.8.3",
     "exif-parser": "~0.1.7",
     "vargs-callback": "~0.2.4",
     "clone": "~1.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "url": "https://github.com/furagu/easy-gd/issues"
   },
   "dependencies": {
-    "node-gd": "~1.1.0",
+    "node-gd": "~1.2.0",
     "buffertools": "~2.1.2",
     "underscore": "~1.7.0",
     "exif-parser": "~0.1.7",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "url": "https://github.com/furagu/easy-gd/issues"
   },
   "dependencies": {
-    "node-gd": "~0.2.3",
+    "node-gd": "~1.0.1",
     "buffertools": "~2.1.2",
     "underscore": "~1.7.0",
     "exif-parser": "~0.1.7",

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -27,7 +27,7 @@ exports.ReadableStream.prototype._read = function() {
 
 
 exports.createImage = function createImage(width, height) {
-    var image = gd.createTrueColor(width || 100, height || 100)
+    var image = gd.createTrueColorSync(width || 100, height || 100)
     greyGradientFill(image, Math.PI/8)
     // image.filledEllipse(50, 50, 25, 25, image.colorAllocate(255, 0, 0))
     return image


### PR DESCRIPTION
Update node-gd to 1.1.0 and still get it to work with node@0.12.7 also.
